### PR TITLE
Feature/api settings

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -11,6 +11,7 @@
         "@google/model-viewer": "^4.1.0",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tanstack/react-query": "^5.82.0",
+        "@tanstack/react-query-devtools": "^5.82.0",
         "@vapor-ui/core": "^0.3.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
@@ -2245,6 +2246,16 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       }
     },
+    "node_modules/@tanstack/query-devtools": {
+      "version": "5.81.2",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-devtools/-/query-devtools-5.81.2.tgz",
+      "integrity": "sha512-jCeJcDCwKfoyyBXjXe9+Lo8aTkavygHHsUHAlxQKKaDeyT0qyQNLKl7+UyqYH2dDF6UN/14873IPBHchcsU+Zg==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
     "node_modules/@tanstack/react-query": {
       "version": "5.82.0",
       "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.82.0.tgz",
@@ -2258,6 +2269,23 @@
         "url": "https://github.com/sponsors/tannerlinsley"
       },
       "peerDependencies": {
+        "react": "^18 || ^19"
+      }
+    },
+    "node_modules/@tanstack/react-query-devtools": {
+      "version": "5.82.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query-devtools/-/react-query-devtools-5.82.0.tgz",
+      "integrity": "sha512-MC05Zq3zr/59jhgF7dL6JSGPg1krbasDSizmRxjNcvxgh/sUTwRFD9CGN10YYX7LB6jq0ZpFtCjSVGdLiFrKAA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-devtools": "5.81.2"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "@tanstack/react-query": "^5.82.0",
         "react": "^18 || ^19"
       }
     },

--- a/package.json
+++ b/package.json
@@ -12,6 +12,7 @@
     "@google/model-viewer": "^4.1.0",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.82.0",
+    "@tanstack/react-query-devtools": "^5.82.0",
     "@vapor-ui/core": "^0.3.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",

--- a/src/actions/auth.ts
+++ b/src/actions/auth.ts
@@ -1,0 +1,11 @@
+"use server";
+
+import { AT_NAME } from "@/constants";
+import { cookies } from "next/headers";
+import { redirect } from "next/navigation";
+
+export const signInAction = async () => {
+  const cookieStore = await cookies();
+  cookieStore.set(AT_NAME, "1234567890");
+  redirect("/");
+};

--- a/src/actions/routes.ts
+++ b/src/actions/routes.ts
@@ -1,0 +1,7 @@
+"use server";
+import { mockRouteData } from "@/constants/mock-data";
+
+export const getAllRoutesAction = async () => {
+  console.log("get all routes actions");
+  return mockRouteData;
+};

--- a/src/app/(main)/collection/page.tsx
+++ b/src/app/(main)/collection/page.tsx
@@ -1,7 +1,33 @@
 import React from "react";
+import {
+  QueryClient,
+  HydrationBoundary,
+  dehydrate,
+} from "@tanstack/react-query";
+import { mockRouteData } from "@/constants/mock-data";
+import Test from "@/components/collection/test";
 
-const CollectionPage = () => {
-  return <div>내 컬렉션</div>;
+const prefetchAllRoutes = async (queryClient: QueryClient) => {
+  const getAllRoutes = async () => {
+    console.log("get all routes rsc");
+    return mockRouteData;
+  };
+  await queryClient.prefetchQuery({
+    queryKey: ["routes"],
+    queryFn: getAllRoutes,
+  });
+};
+
+const CollectionPage = async () => {
+  const queryClient = new QueryClient();
+  await prefetchAllRoutes(queryClient);
+  const dehydratedState = dehydrate(queryClient);
+
+  return (
+    <HydrationBoundary state={dehydratedState}>
+      <Test />
+    </HydrationBoundary>
+  );
 };
 
 export default CollectionPage;

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -2,6 +2,7 @@ import type { Metadata } from "next";
 import Pretendard from "@/styles/local-font";
 import "@/styles/globals.css";
 import { cn } from "@/lib/utils";
+import QueryClientProvider from "@/components/providers/query-client-provider";
 
 export const metadata: Metadata = {
   title: "탐라는사계절",
@@ -15,12 +16,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <body className={cn(Pretendard.className, "antialiased")}>
-        <div className="max-w-[440px] mx-auto">
-          <h1>Global Layout</h1>
-          {children}
-        </div>
-      </body>
+      <QueryClientProvider>
+        <body className={cn(Pretendard.className, "antialiased")}>
+          <div className="max-w-[440px] mx-auto">
+            <h1>Global Layout</h1>
+            {children}
+          </div>
+        </body>
+      </QueryClientProvider>
     </html>
   );
 }

--- a/src/app/layout.tsx
+++ b/src/app/layout.tsx
@@ -16,14 +16,14 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="ko">
-      <QueryClientProvider>
-        <body className={cn(Pretendard.className, "antialiased")}>
+      <body className={cn(Pretendard.className, "antialiased")}>
+        <QueryClientProvider>
           <div className="max-w-[440px] mx-auto">
             <h1>Global Layout</h1>
             {children}
           </div>
-        </body>
-      </QueryClientProvider>
+        </QueryClientProvider>
+      </body>
     </html>
   );
 }

--- a/src/components/collection/test.tsx
+++ b/src/components/collection/test.tsx
@@ -1,0 +1,11 @@
+"use client";
+
+import React from "react";
+import { useRoutes } from "@/hooks/queries/useRoutes";
+
+const Test = () => {
+  const { data } = useRoutes();
+  return <div>{data?.map((route) => route.routeName)}</div>;
+};
+
+export default Test;

--- a/src/components/providers/query-client-provider.tsx
+++ b/src/components/providers/query-client-provider.tsx
@@ -1,0 +1,49 @@
+"use client";
+
+import {
+  isServer,
+  QueryClient,
+  QueryClientProvider,
+} from "@tanstack/react-query";
+import { ReactQueryDevtools } from "@tanstack/react-query-devtools";
+
+function makeQueryClient() {
+  return new QueryClient({
+    defaultOptions: {
+      queries: {
+        staleTime: 60 * 60 * 1000, // 기본 스테일 타임을 1시간으로 설정
+      },
+    },
+  });
+}
+
+let browserQueryClient: QueryClient | undefined = undefined;
+
+function getQueryClient() {
+  if (isServer) {
+    // 서버에서는 항상 새로운 쿼리 클라이언트를 만듭니다.
+    return makeQueryClient();
+  } else {
+    // 브라우저에서는 이미 있는 쿼리 클라이언트가 없으면 새로 만듭니다.
+    if (!browserQueryClient) browserQueryClient = makeQueryClient();
+    return browserQueryClient;
+  }
+}
+
+export function resetQueryClient() {
+  if (browserQueryClient) {
+    browserQueryClient.clear();
+    browserQueryClient = makeQueryClient();
+  }
+}
+
+export default function Provider({ children }: { children: React.ReactNode }) {
+  const queryClient = getQueryClient();
+
+  return (
+    <QueryClientProvider client={queryClient}>
+      {children}
+      <ReactQueryDevtools initialIsOpen={false} />
+    </QueryClientProvider>
+  );
+}

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,0 +1,1 @@
+export const AT_NAME = "accessToken";

--- a/src/constants/mock-data.ts
+++ b/src/constants/mock-data.ts
@@ -1,0 +1,92 @@
+export const mockRouteData = [
+  {
+    routeId: "jeju-001",
+    routeName: "제주 숨은 보석 투어",
+    checkpoints: [
+      {
+        latitude: 33.489,
+        longitude: 126.4983,
+        name: "용머리해안",
+        address: "제주특별자치도 서귀포시 안덕면 사계리 181",
+        description:
+          "화산암이 바다로 뻗어나간 모습이 용의 머리를 닮은 절경지로, 일몰이 아름다운 숨겨진 명소입니다.",
+      },
+      {
+        latitude: 33.3862,
+        longitude: 126.2734,
+        name: "가파도",
+        address: "제주특별자치도 서귀포시 대정읍 가파리",
+        description:
+          "청보리밭으로 유명한 작은 섬으로, 평화로운 자연과 느린 여행의 매력을 느낄 수 있는 곳입니다.",
+      },
+      {
+        latitude: 33.5194,
+        longitude: 126.8003,
+        name: "비자림",
+        address: "제주특별자치도 제주시 구좌읍 평대리 3164-1",
+        description:
+          "500~800년 된 비자나무들이 울창한 숲을 이루는 신비로운 곳으로, 산림욕과 힐링을 즐길 수 있습니다.",
+      },
+    ],
+  },
+  {
+    routeId: "busan-002",
+    routeName: "부산 골목길 탐험",
+    checkpoints: [
+      {
+        latitude: 35.0979,
+        longitude: 129.013,
+        name: "흰여울문화마을",
+        address: "부산광역시 영도구 영선동4가 1043",
+        description:
+          "바다를 내려다보는 계단식 마을로, 흰 파도가 아름다운 인스타그램 핫플레이스입니다.",
+      },
+      {
+        latitude: 35.1284,
+        longitude: 129.0454,
+        name: "40계단 문화관광테마거리",
+        address: "부산광역시 중구 중앙동4가 14-1",
+        description:
+          "6.25 피난민들의 애환이 서린 역사적 장소로, 현재는 문화와 예술이 살아 숨쉬는 거리입니다.",
+      },
+      {
+        latitude: 35.1013,
+        longitude: 129.0306,
+        name: "깡통시장 야시장",
+        address: "부산광역시 동구 중앙대로 179번길 25",
+        description:
+          "부산 대표 전통시장의 야시장으로, 다양한 길거리 음식과 생동감 넘치는 분위기를 즐길 수 있습니다.",
+      },
+    ],
+  },
+  {
+    routeId: "seoul-003",
+    routeName: "서울 골목 보물찾기",
+    checkpoints: [
+      {
+        latitude: 37.5663,
+        longitude: 126.9997,
+        name: "익선동 한옥마을",
+        address: "서울특별시 종로구 익선동 166-71",
+        description:
+          "한옥을 개조한 카페와 상점들이 모여있는 힙한 골목으로, 전통과 현대가 조화를 이루는 곳입니다.",
+      },
+      {
+        latitude: 37.5836,
+        longitude: 127.0024,
+        name: "성수동 수제화 거리",
+        address: "서울특별시 성동구 성수동1가 13-47",
+        description:
+          "오래된 제화공장들이 모여있던 거리가 이제는 핸드메이드 문화의 중심지로 변신한 숨은 명소입니다.",
+      },
+      {
+        latitude: 37.5519,
+        longitude: 126.9748,
+        name: "망원시장 골목",
+        address: "서울특별시 마포구 망원동 394-13",
+        description:
+          "젊은 상인들이 운영하는 개성 넘치는 가게들과 맛집들이 즐비한 로컬 마켓의 매력을 느낄 수 있습니다.",
+      },
+    ],
+  },
+];

--- a/src/hooks/queries/useRoutes.tsx
+++ b/src/hooks/queries/useRoutes.tsx
@@ -1,0 +1,14 @@
+import { useQuery } from "@tanstack/react-query";
+
+import { getAllRoutesAction } from "@/actions/routes";
+
+export const useRoutes = () => {
+  return useQuery({
+    queryKey: ["routes"],
+    queryFn: async () => {
+      const data = await getAllRoutesAction();
+      return data;
+    },
+    staleTime: Infinity,
+  });
+};

--- a/src/lib/api.ts
+++ b/src/lib/api.ts
@@ -1,0 +1,124 @@
+import { ApiResponse, ApiResponseError } from "@/types/common";
+import { AT_NAME } from "@/constants";
+import { cookies } from "next/headers";
+
+// const API_BASE_URL =
+//   process.env.NEXT_PUBLIC_API_BASE_URL ?? process.env.API_BASE_URL;
+
+const API_BASE_URL = "http://localhost:3000";
+
+type HttpMethod = "GET" | "POST" | "PUT" | "PATCH" | "DELETE";
+
+interface ApiRequestInit extends Omit<RequestInit, "body" | "method"> {
+  baseUrl?: string;
+  data?: unknown;
+}
+
+async function createRequest<TResponse>(
+  method: HttpMethod,
+  path: string,
+  { data, ...config }: ApiRequestInit = {}
+): Promise<ApiResponse<TResponse>> {
+  // eslint-disable-next-line prefer-const
+  let { baseUrl, ...restConfig } = config;
+  baseUrl = baseUrl ?? API_BASE_URL;
+  if (!baseUrl) {
+    throw new Error("API_BASE_URL is not defined");
+  }
+
+  let headers: HeadersInit = {
+    "Content-Type": "application/json",
+    ...restConfig.headers,
+  };
+
+  // Handle different content types
+  if (data instanceof FormData) {
+    // Don't set any Content-Type for FormData
+    // Let the browser set it automatically with the correct boundary
+    headers = { ...headers };
+    delete (headers as Record<string, string>)["Content-Type"];
+  } else {
+    (headers as Record<string, string>)["Content-Type"] = "application/json";
+  }
+
+  const cookieStore = await cookies();
+  // Handle cookies differently based on environment
+  if (cookieStore) {
+    // Server-side: manually handle cookies
+    const originalCookies = await cookieStore
+      .getAll()
+      .filter((cookie) => cookie.name !== AT_NAME)
+      .map((cookie) => `${cookie.name}=${cookie.value}`)
+      .join("; ");
+
+    const accessToken = cookieStore.get(AT_NAME)?.value;
+
+    headers = {
+      ...headers,
+      Cookie: originalCookies,
+      Authorization: accessToken ? `Bearer ${accessToken}` : "",
+    };
+  } else {
+    restConfig.credentials = "include";
+  }
+  try {
+    console.log("fetching: ", `${method}: ${baseUrl}${path}`);
+    const response = await fetch(`${baseUrl}${path}`, {
+      ...restConfig,
+      method,
+      credentials: "include",
+      headers, // Use our headers object
+      body:
+        data instanceof FormData
+          ? data
+          : data
+          ? JSON.stringify(data)
+          : undefined,
+    });
+
+    if (!response.ok) {
+      const errorData = await response.json().catch(() => ({}));
+      throw new ApiResponseError(
+        errorData.message || `HTTP Error ${response.status}`,
+        errorData.code || response.status.toString(),
+        errorData.fieldErrors || null
+      );
+    }
+
+    return response;
+  } catch (error) {
+    if (error instanceof ApiResponseError) throw error;
+
+    throw new ApiResponseError(
+      error instanceof Error ? error.message : "Network error occurred",
+      "500",
+      null
+    );
+  }
+}
+
+export const api = {
+  get: <TResponse>(path: string, config?: Omit<ApiRequestInit, "data">) =>
+    createRequest<TResponse>("GET", path, config),
+
+  post: <TResponse, TData = unknown>(
+    path: string,
+    data?: TData,
+    config?: Omit<ApiRequestInit, "data">
+  ) => createRequest<TResponse>("POST", path, { ...config, data }),
+
+  put: <TResponse, TData = unknown>(
+    path: string,
+    data?: TData,
+    config?: Omit<ApiRequestInit, "data">
+  ) => createRequest<TResponse>("PUT", path, { ...config, data }),
+
+  patch: <TResponse, TData = unknown>(
+    path: string,
+    data?: TData,
+    config?: Omit<ApiRequestInit, "data">
+  ) => createRequest<TResponse>("PATCH", path, { ...config, data }),
+
+  delete: <TResponse>(path: string, config?: Omit<ApiRequestInit, "data">) =>
+    createRequest<TResponse>("DELETE", path, config),
+} as const;

--- a/src/types/common.ts
+++ b/src/types/common.ts
@@ -1,0 +1,24 @@
+export interface ApiResponse<T> extends Response {
+  json(): Promise<T>;
+}
+
+export interface ApiFieldError {
+  field: string;
+  message: string;
+}
+
+export class ApiResponseError extends Error {
+  /** @TODO 백엔드 에러 코드들을 constants 안에 저장하고 변수로 사용 */
+  readonly code: string;
+  readonly fieldErrors: ApiFieldError[] | null;
+
+  constructor(
+    message: string,
+    code: string,
+    fieldErrors: ApiFieldError[] | null
+  ) {
+    super(message);
+    this.code = code;
+    this.fieldErrors = fieldErrors;
+  }
+}


### PR DESCRIPTION
API 호출 아키텍처를 구성하였습니다.

`GET` 요청: RSC(보통의 경우 페이지 컴포넌트)에서 백엔드로 `fetch`요청을 날려 미리 `prefetch`해두고, `HydrationBoundary`로 자식을 감싸서 자식이 `useQuery`훅 호출시 캐싱된 데이터 사용가능하도록 한다.
`POST`, `PUT`, `DELETE` 요청: 이런 유형의 요청이 필요한 경우 대부분이 클라이언트 컴포넌트이므로 대응되는 뮤테이션 훅을 만들어서 필요할때 호출하며, 각 뮤테이션 훅에서 대응되는 server-action을 호출한다.