### PR TITLE
메인레이아웃의 새 미션 등록 버튼 추가

### DIFF
--- a/src/app/(main)/layout.tsx
+++ b/src/app/(main)/layout.tsx
@@ -1,7 +1,9 @@
 import React from "react";
 
-import { UserOutlineIcon } from "@vapor-ui/icons";
+import { PlusBoxIcon, UserOutlineIcon } from "@vapor-ui/icons";
 import Navigation from "@/components/home/navigation";
+import Link from "next/link";
+import { Text } from "@vapor-ui/core";
 
 const MainLayout = ({ children }: { children: React.ReactNode }) => {
   return (
@@ -17,6 +19,15 @@ const MainLayout = ({ children }: { children: React.ReactNode }) => {
       <div className="h-[21.16px]" />
       <Navigation />
       {children}
+      <Link
+        href="/new"
+        className="bg-primary h-[85px] flex justify-center items-center rounded-t-[50px] text-white gap-1.5 -mx-5 fixed bottom-0 w-full"
+      >
+        <Text typography="heading4" className="font-semibold text-white">
+          새 미션 등록하기
+        </Text>
+        <PlusBoxIcon size={23} color="white" />
+      </Link>
     </main>
   );
 };

--- a/src/app/(main)/page.tsx
+++ b/src/app/(main)/page.tsx
@@ -62,6 +62,7 @@ const HomePage = () => {
           </button>
         </model-viewer>
       </div> */}
+      <div className="h-28" />
     </div>
   );
 };


### PR DESCRIPTION
<img width="386" alt="image" src="https://github.com/user-attachments/assets/3247eb7d-8c70-4c98-9b2b-b55161c5a62f" />

- 하단의 새 미션 등록하기 버튼을 추가했습니다.
- `fixed`, `bottom-0`로 항상 최하단에 위치하게 하였습니다.
- Link 컴포넌트를 사용했고, "`/new`" 페이지로 이동하게 하였습니다.