### PR TITLE
Feat: 새로운 페이지(캐러셀, 카드 컴포넌트) 기능 구현

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9,6 +9,7 @@
       "version": "0.1.0",
       "dependencies": {
         "@google/model-viewer": "^4.1.0",
+        "@radix-ui/react-slot": "^1.2.3",
         "@radix-ui/react-tooltip": "^1.2.7",
         "@tanstack/react-query": "^5.82.0",
         "@tanstack/react-query-devtools": "^5.82.0",
@@ -16,6 +17,7 @@
         "@vapor-ui/icons": "^0.1.0",
         "class-variance-authority": "^0.7.1",
         "clsx": "^2.1.1",
+        "embla-carousel-react": "^8.6.0",
         "lucide-react": "^0.525.0",
         "motion": "^12.23.0",
         "next": "15.3.5",
@@ -3794,6 +3796,34 @@
       },
       "engines": {
         "node": ">= 0.4"
+      }
+    },
+    "node_modules/embla-carousel": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel/-/embla-carousel-8.6.0.tgz",
+      "integrity": "sha512-SjWyZBHJPbqxHOzckOfo8lHisEaJWmwd23XppYFYVh10bU66/Pn5tkVkbkCMZVdbUE5eTCI2nD8OyIP4Z+uwkA==",
+      "license": "MIT"
+    },
+    "node_modules/embla-carousel-react": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-react/-/embla-carousel-react-8.6.0.tgz",
+      "integrity": "sha512-0/PjqU7geVmo6F734pmPqpyHqiM99olvyecY7zdweCw+6tKEXnrE90pBiBbMMU8s5tICemzpQ3hi5EpxzGW+JA==",
+      "license": "MIT",
+      "dependencies": {
+        "embla-carousel": "8.6.0",
+        "embla-carousel-reactive-utils": "8.6.0"
+      },
+      "peerDependencies": {
+        "react": "^16.8.0 || ^17.0.1 || ^18.0.0 || ^19.0.0 || ^19.0.0-rc"
+      }
+    },
+    "node_modules/embla-carousel-reactive-utils": {
+      "version": "8.6.0",
+      "resolved": "https://registry.npmjs.org/embla-carousel-reactive-utils/-/embla-carousel-reactive-utils-8.6.0.tgz",
+      "integrity": "sha512-fMVUDUEx0/uIEDM0Mz3dHznDhfX+znCCDCeIophYb1QGVM7YThSWX+wz11zlYwWFOr74b4QLGg0hrGPJeG2s4A==",
+      "license": "MIT",
+      "peerDependencies": {
+        "embla-carousel": "8.6.0"
       }
     },
     "node_modules/emoji-regex": {

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
   },
   "dependencies": {
     "@google/model-viewer": "^4.1.0",
+    "@radix-ui/react-slot": "^1.2.3",
     "@radix-ui/react-tooltip": "^1.2.7",
     "@tanstack/react-query": "^5.82.0",
     "@tanstack/react-query-devtools": "^5.82.0",
@@ -17,6 +18,7 @@
     "@vapor-ui/icons": "^0.1.0",
     "class-variance-authority": "^0.7.1",
     "clsx": "^2.1.1",
+    "embla-carousel-react": "^8.6.0",
     "lucide-react": "^0.525.0",
     "motion": "^12.23.0",
     "next": "15.3.5",

--- a/src/app/new/page.tsx
+++ b/src/app/new/page.tsx
@@ -1,7 +1,10 @@
-import React from "react";
+
+import CarouselComponent from '@/components/carousel-component';
 
 const NewMissionPage = () => {
-  return <div>새 미션 페이지</div>;
+  return (
+    <CarouselComponent />
+  );
 };
 
 export default NewMissionPage;

--- a/src/components/card-component.tsx
+++ b/src/components/card-component.tsx
@@ -1,0 +1,94 @@
+"use client";
+
+import React from "react";
+import { Star } from "lucide-react";
+
+interface CardComponentProps {
+  trailName: string;
+  location: string;
+  distance: string;
+  difficulty: number;
+  tags: string[];
+  imageUrl?: string | null;
+}
+
+const CardComponent: React.FC<CardComponentProps> = ({
+  trailName,
+  location,
+  distance,
+  difficulty,
+  tags,
+  imageUrl,
+}) => {
+  return (
+    <div className="flex flex-col bg-white  rounded-2xl p-4">
+      {/* Image Area */}
+      <div className="relative w-full  aspect-square bg-gray-200 rounded-xl overflow-hidden mb-4 border-2 border-[#ADADAD]">
+        {imageUrl ? (
+          <img
+            src={imageUrl}
+            alt={trailName}
+            className="w-full h-full object-cover"
+          />
+        ) : (
+          <div className="w-full h-full flex items-center justify-center">
+            <svg
+              xmlns="http://www.w3.org/2000/svg"
+              width="40"
+              height="67"
+              viewBox="0 0 50 77"
+              fill="none"
+            >
+              <path
+                d="M32.7888 50.7498V51.9261C32.7888 54.1947 31.8645 55.6231 28.8396 55.6231H19.597C16.4041 55.6231 15.3958 53.9427 15.3958 51.2539V49.4894C15.3958 44.7841 17.8325 40.1628 22.3698 35.7935C26.655 31.6763 32.3686 27.7272 32.3686 21.9296C32.3686 17.3083 29.0917 14.9556 24.4704 15.4597C20.6893 15.8799 17.1603 18.1485 17.1603 24.2822C17.1603 26.971 16.152 28.8195 13.0432 28.8195H4.89284C2.12005 28.8195 0.439574 27.3911 0.439574 24.1982C0.35555 6.72125 14.8077 -0.420775 29.5118 1.09166C41.9474 2.35201 49.6776 10.1662 49.6776 21.0893C49.6776 28.6515 45.2243 34.2811 39.6787 39.4906C35.5616 43.3557 32.7888 46.1284 32.7888 50.7498ZM33.545 65.2019V71.1676C33.545 75.2847 32.1166 76.9652 27.6633 76.9652H21.0254C16.5722 76.9652 15.1438 75.2847 15.1438 71.1676V65.2019C15.1438 61.0847 16.5722 59.4042 21.0254 59.4042H27.6633C32.1166 59.4042 33.545 61.0847 33.545 65.2019Z"
+                fill="#707070"
+              />
+            </svg>
+          </div>
+        )}
+      </div>
+
+      {/* Content Area */}
+      <div className="flex flex-col">
+        {/* Title */}
+        <div className="flex items-center justify-between">
+          <h3 className="font-bold truncate text-m">{trailName}</h3>
+
+          <div className="flex items-center ">
+            {[...Array(3)].map((_, i) => (
+              <Star
+                key={i}
+                className={`w-4 h-4 ${
+                  i < difficulty
+                    ? "text-yellow-500 fill-yellow-500"
+                    : "text-gray-300  fill-gray-300"
+                }`}
+              />
+            ))}
+          </div>
+        </div>
+
+        {/* Location & Distance */}
+        <p className="text-xs text-gray-500 mt-1">
+          {location} · {distance}
+        </p>
+
+        {/* Difficulty Stars */}
+
+        {/* Tags */}
+        <div className="flex flex-wrap gap-2 mt-2">
+          {tags.map((tag, index) => (
+            <span
+              key={index}
+              className="bg-[#EAFCF1] text-[#2DDE72] text-xs font-medium px-2 py-0.5 rounded-full"
+            >
+              {tag}
+            </span>
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default CardComponent;

--- a/src/components/carousel-component.tsx
+++ b/src/components/carousel-component.tsx
@@ -1,0 +1,147 @@
+"use client";
+
+import React, { useState, useEffect, useCallback } from "react";
+import useEmblaCarousel from "embla-carousel-react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+import CardComponent from "./card-component";
+
+interface TrailData {
+  trailName: string;
+  location: string;
+  distance: string;
+  difficulty: number;
+  tags: string[];
+  imageUrl?: string | null;
+}
+
+const mockTrails: TrailData[] = [
+  {
+    trailName: "구름 올레",
+    location: "서귀포시 성산읍",
+    distance: "140m",
+    difficulty: 2,
+    tags: ["낭만적", "일출"],
+    imageUrl: null,
+  },
+  {
+    trailName: "바람 올레",
+    location: "제주시 한림읍",
+    distance: "2.5km",
+    difficulty: 3,
+    tags: ["상쾌함", "바다"],
+    imageUrl: null,
+  },
+  {
+    trailName: "숲길 올레",
+    location: "제주시 조천읍",
+    distance: "5km",
+    difficulty: 1,
+    tags: ["힐링", "자연"],
+    imageUrl: null,
+  },
+  {
+    trailName: "오름 올레",
+    location: "서귀포시 안덕면",
+    distance: "3.2km",
+    difficulty: 3,
+    tags: ["도전", "경치"],
+    imageUrl: null,
+  },
+  {
+    trailName: "해안 올레",
+    location: "제주시 애월읍",
+    distance: "7km",
+    difficulty: 2,
+    tags: ["시원함", "노을"],
+    imageUrl: null,
+  },
+];
+
+const CarouselComponent: React.FC = () => {
+  const router = useRouter();
+  const [emblaRef, emblaApi] = useEmblaCarousel({
+    loop: false,
+    align: "start",
+    containScroll: "trimSnaps",
+  });
+  const [selectedIndex, setSelectedIndex] = useState(0);
+
+  const scrollTo = useCallback(
+    (index: number) => {
+      emblaApi?.scrollTo(index);
+    },
+    [emblaApi]
+  );
+
+  const onSelect = useCallback(() => {
+    if (!emblaApi) return;
+    setSelectedIndex(emblaApi.selectedScrollSnap());
+  }, [emblaApi]);
+
+  useEffect(() => {
+    if (!emblaApi) return;
+    onSelect();
+    emblaApi.on("select", onSelect);
+    emblaApi.on("reInit", onSelect);
+  }, [emblaApi, onSelect]);
+
+  return (
+    <div className="flex flex-col min-h-screen bg-[#EAFCF1]">
+      <div className="flex top-8 left-4 z-10 mt-[5%]">
+        <button onClick={() => router.back()} className="p-2">
+          <svg
+            xmlns="http://www.w3.org/2000/svg"
+            width="35"
+            height="35"
+            viewBox="0 0 35 35"
+            fill="none"
+          >
+            <path
+              d="M22.3388 10.7396C22.8941 10.1843 22.8941 9.28402 22.3388 8.72874C21.7836 8.17347 20.8833 8.17347 20.328 8.72874L12.7314 16.3254C12.0827 16.974 12.0827 18.0257 12.7314 18.6744L20.328 26.271C20.8833 26.8263 21.7836 26.8263 22.3389 26.271C22.8941 25.7158 22.8941 24.8155 22.3388 24.2602L15.5785 17.4999L22.3388 10.7396Z"
+              fill="#515151"
+            />
+          </svg>
+        </button>
+      </div>
+
+      <h1 className="text-m font-bold text-center text-gray-800 w-[64%] mx-auto">
+        지금, 이 순간 당신에게 <br /> 가장 어울리는 길은 어디일까요?
+      </h1>
+
+      <div className="flex justify-center mt-[5%]">
+        <div className="w-full overflow-hidden pl-[14.5%]" ref={emblaRef}>
+          <div className="flex -ml-4">
+            {mockTrails.map((trail, index) => (
+              <div key={index} className="flex-none w-[71%] pl-4">
+                <CardComponent {...trail} />
+              </div>
+            ))}
+          </div>
+        </div>
+      </div>
+
+      <div className="flex justify-center mt-8 mb-12">
+        {mockTrails.map((_, index) => (
+          <button
+            key={index}
+            onClick={() => scrollTo(index)}
+            className={`h-2.5 w-2.5 mx-1.5 rounded-full transition-colors duration-300 ${
+              selectedIndex === index ? "bg-[#2DDE72]" : "bg-gray-300"
+            }`}
+          />
+        ))}
+      </div>
+
+      <div className="flex justify-center px-4">
+        <Link href="#" className="w-[76%] max-w-md">
+          <button className="w-full bg-[#2DDE72] text-white text-m font-bold py-4 px-8 rounded-[22px] hover:bg-green-500 transition-colors duration-300">
+            지도 생성하기
+          </button>
+        </Link>
+      </div>
+    </div>
+  );
+};
+
+export default CarouselComponent;

--- a/src/components/ui/button.tsx
+++ b/src/components/ui/button.tsx
@@ -1,0 +1,59 @@
+import * as React from "react"
+import { Slot } from "@radix-ui/react-slot"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "@/lib/utils"
+
+const buttonVariants = cva(
+  "inline-flex items-center justify-center gap-2 whitespace-nowrap rounded-md text-sm font-medium transition-all disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4 shrink-0 [&_svg]:shrink-0 outline-none focus-visible:border-ring focus-visible:ring-ring/50 focus-visible:ring-[3px] aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive",
+  {
+    variants: {
+      variant: {
+        default:
+          "bg-primary text-primary-foreground shadow-xs hover:bg-primary/90",
+        destructive:
+          "bg-destructive text-white shadow-xs hover:bg-destructive/90 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/60",
+        outline:
+          "border bg-background shadow-xs hover:bg-accent hover:text-accent-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50",
+        secondary:
+          "bg-secondary text-secondary-foreground shadow-xs hover:bg-secondary/80",
+        ghost:
+          "hover:bg-accent hover:text-accent-foreground dark:hover:bg-accent/50",
+        link: "text-primary underline-offset-4 hover:underline",
+      },
+      size: {
+        default: "h-9 px-4 py-2 has-[>svg]:px-3",
+        sm: "h-8 rounded-md gap-1.5 px-3 has-[>svg]:px-2.5",
+        lg: "h-10 rounded-md px-6 has-[>svg]:px-4",
+        icon: "size-9",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Button({
+  className,
+  variant,
+  size,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"button"> &
+  VariantProps<typeof buttonVariants> & {
+    asChild?: boolean
+  }) {
+  const Comp = asChild ? Slot : "button"
+
+  return (
+    <Comp
+      data-slot="button"
+      className={cn(buttonVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+export { Button, buttonVariants }

--- a/src/components/ui/carousel.tsx
+++ b/src/components/ui/carousel.tsx
@@ -1,0 +1,241 @@
+"use client"
+
+import * as React from "react"
+import useEmblaCarousel, {
+  type UseEmblaCarouselType,
+} from "embla-carousel-react"
+import { ArrowLeft, ArrowRight } from "lucide-react"
+
+import { cn } from "@/lib/utils"
+import { Button } from "@/components/ui/button"
+
+type CarouselApi = UseEmblaCarouselType[1]
+type UseCarouselParameters = Parameters<typeof useEmblaCarousel>
+type CarouselOptions = UseCarouselParameters[0]
+type CarouselPlugin = UseCarouselParameters[1]
+
+type CarouselProps = {
+  opts?: CarouselOptions
+  plugins?: CarouselPlugin
+  orientation?: "horizontal" | "vertical"
+  setApi?: (api: CarouselApi) => void
+}
+
+type CarouselContextProps = {
+  carouselRef: ReturnType<typeof useEmblaCarousel>[0]
+  api: ReturnType<typeof useEmblaCarousel>[1]
+  scrollPrev: () => void
+  scrollNext: () => void
+  canScrollPrev: boolean
+  canScrollNext: boolean
+} & CarouselProps
+
+const CarouselContext = React.createContext<CarouselContextProps | null>(null)
+
+function useCarousel() {
+  const context = React.useContext(CarouselContext)
+
+  if (!context) {
+    throw new Error("useCarousel must be used within a <Carousel />")
+  }
+
+  return context
+}
+
+function Carousel({
+  orientation = "horizontal",
+  opts,
+  setApi,
+  plugins,
+  className,
+  children,
+  ...props
+}: React.ComponentProps<"div"> & CarouselProps) {
+  const [carouselRef, api] = useEmblaCarousel(
+    {
+      ...opts,
+      axis: orientation === "horizontal" ? "x" : "y",
+    },
+    plugins
+  )
+  const [canScrollPrev, setCanScrollPrev] = React.useState(false)
+  const [canScrollNext, setCanScrollNext] = React.useState(false)
+
+  const onSelect = React.useCallback((api: CarouselApi) => {
+    if (!api) return
+    setCanScrollPrev(api.canScrollPrev())
+    setCanScrollNext(api.canScrollNext())
+  }, [])
+
+  const scrollPrev = React.useCallback(() => {
+    api?.scrollPrev()
+  }, [api])
+
+  const scrollNext = React.useCallback(() => {
+    api?.scrollNext()
+  }, [api])
+
+  const handleKeyDown = React.useCallback(
+    (event: React.KeyboardEvent<HTMLDivElement>) => {
+      if (event.key === "ArrowLeft") {
+        event.preventDefault()
+        scrollPrev()
+      } else if (event.key === "ArrowRight") {
+        event.preventDefault()
+        scrollNext()
+      }
+    },
+    [scrollPrev, scrollNext]
+  )
+
+  React.useEffect(() => {
+    if (!api || !setApi) return
+    setApi(api)
+  }, [api, setApi])
+
+  React.useEffect(() => {
+    if (!api) return
+    onSelect(api)
+    api.on("reInit", onSelect)
+    api.on("select", onSelect)
+
+    return () => {
+      api?.off("select", onSelect)
+    }
+  }, [api, onSelect])
+
+  return (
+    <CarouselContext.Provider
+      value={{
+        carouselRef,
+        api: api,
+        opts,
+        orientation:
+          orientation || (opts?.axis === "y" ? "vertical" : "horizontal"),
+        scrollPrev,
+        scrollNext,
+        canScrollPrev,
+        canScrollNext,
+      }}
+    >
+      <div
+        onKeyDownCapture={handleKeyDown}
+        className={cn("relative", className)}
+        role="region"
+        aria-roledescription="carousel"
+        data-slot="carousel"
+        {...props}
+      >
+        {children}
+      </div>
+    </CarouselContext.Provider>
+  )
+}
+
+function CarouselContent({ className, ...props }: React.ComponentProps<"div">) {
+  const { carouselRef, orientation } = useCarousel()
+
+  return (
+    <div
+      ref={carouselRef}
+      className="overflow-hidden"
+      data-slot="carousel-content"
+    >
+      <div
+        className={cn(
+          "flex",
+          orientation === "horizontal" ? "-ml-4" : "-mt-4 flex-col",
+          className
+        )}
+        {...props}
+      />
+    </div>
+  )
+}
+
+function CarouselItem({ className, ...props }: React.ComponentProps<"div">) {
+  const { orientation } = useCarousel()
+
+  return (
+    <div
+      role="group"
+      aria-roledescription="slide"
+      data-slot="carousel-item"
+      className={cn(
+        "min-w-0 shrink-0 grow-0 basis-full",
+        orientation === "horizontal" ? "pl-4" : "pt-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function CarouselPrevious({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollPrev, canScrollPrev } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-previous"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute size-8 rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -left-12 -translate-y-1/2"
+          : "-top-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollPrev}
+      onClick={scrollPrev}
+      {...props}
+    >
+      <ArrowLeft />
+      <span className="sr-only">Previous slide</span>
+    </Button>
+  )
+}
+
+function CarouselNext({
+  className,
+  variant = "outline",
+  size = "icon",
+  ...props
+}: React.ComponentProps<typeof Button>) {
+  const { orientation, scrollNext, canScrollNext } = useCarousel()
+
+  return (
+    <Button
+      data-slot="carousel-next"
+      variant={variant}
+      size={size}
+      className={cn(
+        "absolute size-8 rounded-full",
+        orientation === "horizontal"
+          ? "top-1/2 -right-12 -translate-y-1/2"
+          : "-bottom-12 left-1/2 -translate-x-1/2 rotate-90",
+        className
+      )}
+      disabled={!canScrollNext}
+      onClick={scrollNext}
+      {...props}
+    >
+      <ArrowRight />
+      <span className="sr-only">Next slide</span>
+    </Button>
+  )
+}
+
+export {
+  type CarouselApi,
+  Carousel,
+  CarouselContent,
+  CarouselItem,
+  CarouselPrevious,
+  CarouselNext,
+}


### PR DESCRIPTION
   - 캐러셀 기능 구현
       - embla-carousel-react를 사용하여 스와이프 기반 캐러셀을 구현했음.
       - 첫 화면에서 중앙 카드와 다음 카드가 보이도록 캐러셀 UI를 구현했음.
       - 캐러셀 loop 기능을 비활성화하여 첫 카드에서 뒤로 가는 동작을 막도록 구현했음.


   - 카드 컴포넌트 신규 구현
       - 그림자, 둥근 모서리, 여백을 적용한 카드 컴포넌트를 구현했음.
       - 이미지 영역은 정사각형 비율로 고정하고, 이미지가 없을 경우 커스텀 SVG 아이콘을 표시하도록 구현했음.
       - 난이도는 별 아이콘으로, 태그는 요청된 스타일로 구현했음.


   - 페이지 레이아웃 및 기능 추가
       - useRouter를 사용하여 이전 페이지로 이동하는 '뒤로 가기' 버튼을 추가했음.
       - 페이지 제목의 스타일(너비, 중앙 정렬, 줄바꿈)을 적용했음.
       - 하단 "지도 생성하기" 버튼의 스타일을 적용하고 next/link를 추가했음.


   - 최종 요구사항 반영
       - 모든 카드의 imageUrl을 null로 설정하여 기본 SVG 아이콘이 표시되도록 했음.
       - isActive 관련 로직을 모두 제거하여 모든 카드가 동일한 스타일을 갖도록 최종 수정했음